### PR TITLE
Implement deployment API support for ant-man and flash previews

### DIFF
--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -112,8 +112,8 @@ public class GHDeployment extends GHObject {
     }
 
     /**
-     * Specifies if the given environment is specific to the deployment
-     * and will no longer exist at some point in the future.
+     * Specifies if the given environment is specific to the deployment and will no longer exist at some point in the
+     * future.
      *
      * @return the environment is transient
      */

--- a/src/main/java/org/kohsuke/github/GHDeployment.java
+++ b/src/main/java/org/kohsuke/github/GHDeployment.java
@@ -24,6 +24,9 @@ public class GHDeployment extends GHObject {
     protected String statuses_url;
     protected String repository_url;
     protected GHUser creator;
+    protected String original_environment;
+    protected boolean transient_environment;
+    protected boolean production_environment;
 
     GHDeployment wrap(GHRepository owner) {
         this.owner = owner;
@@ -90,12 +93,43 @@ public class GHDeployment extends GHObject {
     }
 
     /**
+     * The environment defined when the deployment was first created.
+     *
+     * @return the original deployment environment
+     */
+    @Preview(Previews.FLASH)
+    public String getOriginalEnvironment() {
+        return original_environment;
+    }
+
+    /**
      * Gets environment.
      *
      * @return the environment
      */
     public String getEnvironment() {
         return environment;
+    }
+
+    /**
+     * Specifies if the given environment is specific to the deployment
+     * and will no longer exist at some point in the future.
+     *
+     * @return the environment is transient
+     */
+    @Preview(Previews.ANT_MAN)
+    public boolean isTransientEnvironment() {
+        return transient_environment;
+    }
+
+    /**
+     * Specifies if the given environment is one that end-users directly interact with.
+     *
+     * @return the environment is used by end-users directly
+     */
+    @Preview(Previews.ANT_MAN)
+    public boolean isProductionEnvironment() {
+        return production_environment;
     }
 
     /**
@@ -154,6 +188,8 @@ public class GHDeployment extends GHObject {
     public PagedIterable<GHDeploymentStatus> listStatuses() {
         return root.createRequest()
                 .withUrlPath(statuses_url)
+                .withPreview(Previews.ANT_MAN)
+                .withPreview(Previews.FLASH)
                 .toIterable(GHDeploymentStatus[].class, item -> item.wrap(owner));
     }
 

--- a/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
@@ -19,7 +19,9 @@ public class GHDeploymentBuilder {
      */
     public GHDeploymentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.builder = repo.root.createRequest().withPreview(Previews.ANT_MAN).withPreview(Previews.FLASH)
+        this.builder = repo.root.createRequest()
+                .withPreview(Previews.ANT_MAN)
+                .withPreview(Previews.FLASH)
                 .method("POST");
     }
 

--- a/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
@@ -19,10 +19,8 @@ public class GHDeploymentBuilder {
      */
     public GHDeploymentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.builder = repo.root.createRequest()
-            .withPreview(Previews.ANT_MAN)
-            .withPreview(Previews.FLASH)
-            .method("POST");
+        this.builder = repo.root.createRequest().withPreview(Previews.ANT_MAN).withPreview(Previews.FLASH)
+                .method("POST");
     }
 
     /**
@@ -43,6 +41,7 @@ public class GHDeploymentBuilder {
      *
      * @param branch
      *            the branch
+     *
      * @return the gh deployment builder
      */
     public GHDeploymentBuilder ref(String branch) {
@@ -55,6 +54,7 @@ public class GHDeploymentBuilder {
      *
      * @param task
      *            the task
+     *
      * @return the gh deployment builder
      */
     public GHDeploymentBuilder task(String task) {
@@ -67,6 +67,7 @@ public class GHDeploymentBuilder {
      *
      * @param autoMerge
      *            the auto merge
+     *
      * @return the gh deployment builder
      */
     public GHDeploymentBuilder autoMerge(boolean autoMerge) {
@@ -79,6 +80,7 @@ public class GHDeploymentBuilder {
      *
      * @param requiredContexts
      *            the required contexts
+     *
      * @return the gh deployment builder
      */
     public GHDeploymentBuilder requiredContexts(List<String> requiredContexts) {
@@ -91,6 +93,7 @@ public class GHDeploymentBuilder {
      *
      * @param payload
      *            the payload
+     *
      * @return the gh deployment builder
      */
     public GHDeploymentBuilder payload(String payload) {
@@ -103,6 +106,7 @@ public class GHDeploymentBuilder {
      *
      * @param environment
      *            the environment
+     *
      * @return the gh deployment builder
      */
     public GHDeploymentBuilder environment(String environment) {
@@ -111,11 +115,12 @@ public class GHDeploymentBuilder {
     }
 
     /**
-     * Specifies if the given environment is specific to the deployment
-     * and will no longer exist at some point in the future.
+     * Specifies if the given environment is specific to the deployment and will no longer exist at some point in the
+     * future.
      *
      * @param transientEnvironment
      *            the environment is transient
+     *
      * @return the gh deployment builder
      */
     @Preview(Previews.ANT_MAN)
@@ -129,6 +134,7 @@ public class GHDeploymentBuilder {
      *
      * @param productionEnvironment
      *            the environment is used by end-users directly
+     *
      * @return the gh deployment builder
      */
     @Preview(Previews.ANT_MAN)
@@ -142,6 +148,7 @@ public class GHDeploymentBuilder {
      *
      * @param description
      *            the description
+     *
      * @return the gh deployment builder
      */
     public GHDeploymentBuilder description(String description) {
@@ -153,6 +160,7 @@ public class GHDeploymentBuilder {
      * Create gh deployment.
      *
      * @return the gh deployment
+     *
      * @throws IOException
      *             the io exception
      */

--- a/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentBuilder.java
@@ -19,7 +19,10 @@ public class GHDeploymentBuilder {
      */
     public GHDeploymentBuilder(GHRepository repo) {
         this.repo = repo;
-        this.builder = repo.root.createRequest().method("POST");
+        this.builder = repo.root.createRequest()
+            .withPreview(Previews.ANT_MAN)
+            .withPreview(Previews.FLASH)
+            .method("POST");
     }
 
     /**
@@ -104,6 +107,33 @@ public class GHDeploymentBuilder {
      */
     public GHDeploymentBuilder environment(String environment) {
         builder.with("environment", environment);
+        return this;
+    }
+
+    /**
+     * Specifies if the given environment is specific to the deployment
+     * and will no longer exist at some point in the future.
+     *
+     * @param transientEnvironment
+     *            the environment is transient
+     * @return the gh deployment builder
+     */
+    @Preview(Previews.ANT_MAN)
+    public GHDeploymentBuilder transientEnvironment(boolean transientEnvironment) {
+        builder.with("transient_environment", transientEnvironment);
+        return this;
+    }
+
+    /**
+     * Specifies if the given environment is one that end-users directly interact with.
+     *
+     * @param productionEnvironment
+     *            the environment is used by end-users directly
+     * @return the gh deployment builder
+     */
+    @Preview(Previews.ANT_MAN)
+    public GHDeploymentBuilder productionEnvironment(boolean productionEnvironment) {
+        builder.with("production_environment", productionEnvironment);
         return this;
     }
 

--- a/src/main/java/org/kohsuke/github/GHDeploymentState.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentState.java
@@ -4,7 +4,10 @@ package org.kohsuke.github;
  * Represents the state of deployment
  */
 public enum GHDeploymentState {
-    PENDING, SUCCESS, ERROR, FAILURE,
+    PENDING,
+    SUCCESS,
+    ERROR,
+    FAILURE,
 
     @Preview(Previews.FLASH)
     IN_PROGRESS,

--- a/src/main/java/org/kohsuke/github/GHDeploymentState.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentState.java
@@ -4,10 +4,7 @@ package org.kohsuke.github;
  * Represents the state of deployment
  */
 public enum GHDeploymentState {
-    PENDING,
-    SUCCESS,
-    ERROR,
-    FAILURE,
+    PENDING, SUCCESS, ERROR, FAILURE,
 
     @Preview(Previews.FLASH)
     IN_PROGRESS,

--- a/src/main/java/org/kohsuke/github/GHDeploymentState.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentState.java
@@ -4,5 +4,17 @@ package org.kohsuke.github;
  * Represents the state of deployment
  */
 public enum GHDeploymentState {
-    PENDING, SUCCESS, ERROR, FAILURE
+    PENDING,
+    SUCCESS,
+    ERROR,
+    FAILURE,
+
+    @Preview(Previews.FLASH)
+    IN_PROGRESS,
+
+    @Preview(Previews.FLASH)
+    QUEUED,
+
+    @Preview(Previews.ANT_MAN)
+    INACTIVE
 }

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
@@ -23,6 +23,7 @@ public class GHDeploymentStatus extends GHObject {
      *
      * @param owner
      *            the owner
+     *
      * @return the gh deployment status
      */
     public GHDeploymentStatus wrap(GHRepository owner) {
@@ -37,6 +38,7 @@ public class GHDeploymentStatus extends GHObject {
      * Gets target url.
      *
      * @deprecated Target url is deprecated in favor of {@link #getLogUrl() getLogUrl}
+     *
      * @return the target url
      */
     @Deprecated

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatus.java
@@ -13,8 +13,10 @@ public class GHDeploymentStatus extends GHObject {
     protected String state;
     protected String description;
     protected String target_url;
+    protected String log_url;
     protected String deployment_url;
     protected String repository_url;
+    protected String environment_url;
 
     /**
      * Wrap gh deployment status.
@@ -34,9 +36,22 @@ public class GHDeploymentStatus extends GHObject {
     /**
      * Gets target url.
      *
+     * @deprecated Target url is deprecated in favor of {@link #getLogUrl() getLogUrl}
      * @return the target url
      */
+    @Deprecated
     public URL getTargetUrl() {
+        return GitHubClient.parseURL(target_url);
+    }
+
+    /**
+     * Gets target url.
+     * <p>
+     * This method replaces {@link #getTargetUrl() getTargetUrl}}.
+     *
+     * @return the target url
+     */
+    public URL getLogUrl() {
         return GitHubClient.parseURL(target_url);
     }
 
@@ -47,6 +62,15 @@ public class GHDeploymentStatus extends GHObject {
      */
     public URL getDeploymentUrl() {
         return GitHubClient.parseURL(deployment_url);
+    }
+
+    /**
+     * Gets deployment environment url.
+     *
+     * @return the deployment environment url
+     */
+    public URL getEnvironmentUrl() {
+        return GitHubClient.parseURL(environment_url);
     }
 
     /**

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
@@ -32,7 +32,9 @@ public class GHDeploymentStatusBuilder {
     GHDeploymentStatusBuilder(GHRepository repo, long deploymentId, GHDeploymentState state) {
         this.repo = repo;
         this.deploymentId = deploymentId;
-        this.builder = repo.root.createRequest().withPreview(Previews.ANT_MAN).withPreview(Previews.FLASH)
+        this.builder = repo.root.createRequest()
+                .withPreview(Previews.ANT_MAN)
+                .withPreview(Previews.FLASH)
                 .method("POST");
 
         this.builder.with("state", state);
@@ -136,6 +138,7 @@ public class GHDeploymentStatusBuilder {
      */
     public GHDeploymentStatus create() throws IOException {
         return builder.withUrlPath(repo.getApiTailUrl("deployments/" + deploymentId + "/statuses"))
-                .fetch(GHDeploymentStatus.class).wrap(repo);
+                .fetch(GHDeploymentStatus.class)
+                .wrap(repo);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
@@ -21,6 +21,7 @@ public class GHDeploymentStatusBuilder {
      *            the deployment id
      * @param state
      *            the state
+     *
      * @deprecated Use {@link GHDeployment#createStatus(GHDeploymentState)}
      */
     @Deprecated
@@ -31,22 +32,22 @@ public class GHDeploymentStatusBuilder {
     GHDeploymentStatusBuilder(GHRepository repo, long deploymentId, GHDeploymentState state) {
         this.repo = repo;
         this.deploymentId = deploymentId;
-        this.builder = repo.root.createRequest()
-            .withPreview(Previews.ANT_MAN)
-            .withPreview(Previews.FLASH)
-            .method("POST");
+        this.builder = repo.root.createRequest().withPreview(Previews.ANT_MAN).withPreview(Previews.FLASH)
+                .method("POST");
 
         this.builder.with("state", state);
     }
 
     /**
-     * Add an inactive status to all prior non-transient, non-production environment deployments
-     * with the same repository and environment name as the created status's deployment.
+     * Add an inactive status to all prior non-transient, non-production environment deployments with the same
+     * repository and environment name as the created status's deployment.
      *
-     * @param autoInactive Add inactive status flag
+     * @param autoInactive
+     *            Add inactive status flag
+     *
      * @return the gh deployment status builder
      */
-    @Preview({Previews.ANT_MAN,Previews.FLASH})
+    @Preview({ Previews.ANT_MAN, Previews.FLASH })
     public GHDeploymentStatusBuilder autoInactive(boolean autoInactive) {
         this.builder.with("auto_inactive", autoInactive);
         return this;
@@ -57,6 +58,7 @@ public class GHDeploymentStatusBuilder {
      *
      * @param description
      *            the description
+     *
      * @return the gh deployment status builder
      */
     public GHDeploymentStatusBuilder description(String description) {
@@ -65,11 +67,11 @@ public class GHDeploymentStatusBuilder {
     }
 
     /**
-     * Name for the target deployment environment, which can be
-     * changed when setting a deploy status.
+     * Name for the target deployment environment, which can be changed when setting a deploy status.
      *
      * @param environment
      *            the environment name
+     *
      * @return the gh deployment status builder
      */
     @Preview(Previews.FLASH)
@@ -83,6 +85,7 @@ public class GHDeploymentStatusBuilder {
      *
      * @param environmentUrl
      *            the environment url
+     *
      * @return the gh deployment status builder
      */
     @Preview(Previews.ANT_MAN)
@@ -98,6 +101,7 @@ public class GHDeploymentStatusBuilder {
      *
      * @param logUrl
      *            the deployment output url
+     *
      * @return the gh deployment status builder
      */
     @Preview(Previews.ANT_MAN)
@@ -110,8 +114,10 @@ public class GHDeploymentStatusBuilder {
      * Target url gh deployment status builder.
      *
      * @deprecated Target url is deprecated in favor of {@link #logUrl(String) logUrl}
+     *
      * @param targetUrl
      *            the target url
+     *
      * @return the gh deployment status builder
      */
     @Deprecated
@@ -124,12 +130,12 @@ public class GHDeploymentStatusBuilder {
      * Create gh deployment status.
      *
      * @return the gh deployment status
+     *
      * @throws IOException
      *             the io exception
      */
     public GHDeploymentStatus create() throws IOException {
         return builder.withUrlPath(repo.getApiTailUrl("deployments/" + deploymentId + "/statuses"))
-                .fetch(GHDeploymentStatus.class)
-                .wrap(repo);
+                .fetch(GHDeploymentStatus.class).wrap(repo);
     }
 }

--- a/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
+++ b/src/main/java/org/kohsuke/github/GHDeploymentStatusBuilder.java
@@ -31,8 +31,25 @@ public class GHDeploymentStatusBuilder {
     GHDeploymentStatusBuilder(GHRepository repo, long deploymentId, GHDeploymentState state) {
         this.repo = repo;
         this.deploymentId = deploymentId;
-        this.builder = repo.root.createRequest().method("POST");
+        this.builder = repo.root.createRequest()
+            .withPreview(Previews.ANT_MAN)
+            .withPreview(Previews.FLASH)
+            .method("POST");
+
         this.builder.with("state", state);
+    }
+
+    /**
+     * Add an inactive status to all prior non-transient, non-production environment deployments
+     * with the same repository and environment name as the created status's deployment.
+     *
+     * @param autoInactive Add inactive status flag
+     * @return the gh deployment status builder
+     */
+    @Preview({Previews.ANT_MAN,Previews.FLASH})
+    public GHDeploymentStatusBuilder autoInactive(boolean autoInactive) {
+        this.builder.with("auto_inactive", autoInactive);
+        return this;
     }
 
     /**
@@ -48,12 +65,56 @@ public class GHDeploymentStatusBuilder {
     }
 
     /**
+     * Name for the target deployment environment, which can be
+     * changed when setting a deploy status.
+     *
+     * @param environment
+     *            the environment name
+     * @return the gh deployment status builder
+     */
+    @Preview(Previews.FLASH)
+    public GHDeploymentStatusBuilder environment(String environment) {
+        this.builder.with("environment", environment);
+        return this;
+    }
+
+    /**
+     * The URL for accessing the environment
+     *
+     * @param environmentUrl
+     *            the environment url
+     * @return the gh deployment status builder
+     */
+    @Preview(Previews.ANT_MAN)
+    public GHDeploymentStatusBuilder environmentUrl(String environmentUrl) {
+        this.builder.with("environment_url", environmentUrl);
+        return this;
+    }
+
+    /**
+     * The full URL of the deployment's output.
+     * <p>
+     * This method replaces {@link #targetUrl(String) targetUrl}.
+     *
+     * @param logUrl
+     *            the deployment output url
+     * @return the gh deployment status builder
+     */
+    @Preview(Previews.ANT_MAN)
+    public GHDeploymentStatusBuilder logUrl(String logUrl) {
+        this.builder.with("log_url", logUrl);
+        return this;
+    }
+
+    /**
      * Target url gh deployment status builder.
      *
+     * @deprecated Target url is deprecated in favor of {@link #logUrl(String) logUrl}
      * @param targetUrl
      *            the target url
      * @return the gh deployment status builder
      */
+    @Deprecated
     public GHDeploymentStatusBuilder targetUrl(String targetUrl) {
         this.builder.with("target_url", targetUrl);
         return this;

--- a/src/main/java/org/kohsuke/github/GHRepository.java
+++ b/src/main/java/org/kohsuke/github/GHRepository.java
@@ -163,6 +163,8 @@ public class GHRepository extends GHObject {
                 .with("task", task)
                 .with("environment", environment)
                 .withUrlPath(getApiTailUrl("deployments"))
+                .withPreview(ANT_MAN)
+                .withPreview(FLASH)
                 .toIterable(GHDeployment[].class, item -> item.wrap(this));
     }
 
@@ -178,6 +180,8 @@ public class GHRepository extends GHObject {
     public GHDeployment getDeployment(long id) throws IOException {
         return root.createRequest()
                 .withUrlPath(getApiTailUrl("deployments/" + id))
+                .withPreview(ANT_MAN)
+                .withPreview(FLASH)
                 .fetch(GHDeployment.class)
                 .wrap(this);
     }

--- a/src/main/java/org/kohsuke/github/Preview.java
+++ b/src/main/java/org/kohsuke/github/Preview.java
@@ -15,4 +15,15 @@ import java.lang.annotation.RetentionPolicy;
 @Retention(RetentionPolicy.RUNTIME)
 @Documented
 public @interface Preview {
+
+  /**
+   * An optional field defining what API media types must be set inorder to support the
+   * usage of this annotations target.
+   * <p>
+   * This value should be set using the existing constants defined in {@link Previews}
+   *
+   * @return The API preview media type.
+   */
+  public String[] value() default {};
+
 }

--- a/src/main/java/org/kohsuke/github/Preview.java
+++ b/src/main/java/org/kohsuke/github/Preview.java
@@ -16,14 +16,14 @@ import java.lang.annotation.RetentionPolicy;
 @Documented
 public @interface Preview {
 
-  /**
-   * An optional field defining what API media types must be set inorder to support the
-   * usage of this annotations target.
-   * <p>
-   * This value should be set using the existing constants defined in {@link Previews}
-   *
-   * @return The API preview media type.
-   */
-  public String[] value() default {};
+    /**
+     * An optional field defining what API media types must be set inorder to support the usage of this annotations
+     * target.
+     * <p>
+     * This value should be set using the existing constants defined in {@link Previews}
+     *
+     * @return The API preview media type.
+     */
+    public String[] value() default {};
 
 }

--- a/src/main/java/org/kohsuke/github/Previews.java
+++ b/src/main/java/org/kohsuke/github/Previews.java
@@ -31,6 +31,13 @@ class Previews {
     static final String CLOAK = "application/vnd.github.cloak-preview+json";
 
     /**
+     * New deployment statuses and support for updating deployment status environment
+     *
+     * @see <a href="https://developer.github.com/v3/previews/#deployment-statuses">GitHub API Previews</a>
+     */
+    static final String FLASH = "application/vnd.github.flash-preview+json";
+    
+    /**
      * Owners of GitHub Apps can now uninstall an app using the Apps API
      *
      * @see <a href="https://developer.github.com/v3/previews/#uninstall-a-github-app">GitHub API Previews</a>

--- a/src/main/java/org/kohsuke/github/Previews.java
+++ b/src/main/java/org/kohsuke/github/Previews.java
@@ -16,6 +16,13 @@ class Previews {
     static final String ANTIOPE = "application/vnd.github.antiope-preview+json";
 
     /**
+     * Enhanced Deployments
+     *
+     * @see <a href="https://developer.github.com/v3/previews/#enhanced-deployments">GitHub API Previews</a>
+     */
+    static final String ANT_MAN = "application/vnd.github.ant-man-preview+json";
+
+    /**
      * Create repository from template repository
      *
      * @see <a href="https://developer.github.com/v3/previews/#create-and-use-repository-templates">GitHub API
@@ -36,7 +43,7 @@ class Previews {
      * @see <a href="https://developer.github.com/v3/previews/#deployment-statuses">GitHub API Previews</a>
      */
     static final String FLASH = "application/vnd.github.flash-preview+json";
-    
+
     /**
      * Owners of GitHub Apps can now uninstall an app using the Apps API
      *

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -175,9 +175,7 @@ public class AppTest extends AbstractGitHubWireMockTest {
                 .create();
         assertNotNull(deployment.getCreator());
         assertNotNull(deployment.getId());
-        List<GHDeployment> deployments = repository
-            .listDeployments(null, "master", null, "unittest")
-            .toList();
+        List<GHDeployment> deployments = repository.listDeployments(null, "master", null, "unittest").toList();
         assertNotNull(deployments);
         assertFalse(Iterables.isEmpty(deployments));
         GHDeployment unitTestDeployment = deployments.get(0);
@@ -211,9 +209,8 @@ public class AppTest extends AbstractGitHubWireMockTest {
         assertEquals(ghDeploymentStatus.getState(), actualStatus.getState());
         assertEquals(ghDeploymentStatus.getLogUrl(), actualStatus.getLogUrl());
         // Target url was deprecated and replaced with log url. The gh api will
-        // prefer the log url value and return it in target field
+        // prefer the log url value and return it in place of target url.
         assertEquals(ghDeploymentStatus.getTargetUrl(), actualStatus.getLogUrl());
-
     }
 
     @Test

--- a/src/test/java/org/kohsuke/github/AppTest.java
+++ b/src/test/java/org/kohsuke/github/AppTest.java
@@ -175,11 +175,16 @@ public class AppTest extends AbstractGitHubWireMockTest {
                 .create();
         assertNotNull(deployment.getCreator());
         assertNotNull(deployment.getId());
-        List<GHDeployment> deployments = repository.listDeployments(null, "master", null, "unittest").toList();
+        List<GHDeployment> deployments = repository
+            .listDeployments(null, "master", null, "unittest")
+            .toList();
         assertNotNull(deployments);
         assertFalse(Iterables.isEmpty(deployments));
         GHDeployment unitTestDeployment = deployments.get(0);
         assertEquals("unittest", unitTestDeployment.getEnvironment());
+        assertEquals("unittest", unitTestDeployment.getOriginalEnvironment());
+        assertEquals(false, unitTestDeployment.isProductionEnvironment());
+        assertEquals(true, unitTestDeployment.isTransientEnvironment());
         assertEquals("master", unitTestDeployment.getRef());
     }
 
@@ -191,14 +196,24 @@ public class AppTest extends AbstractGitHubWireMockTest {
                 .description("question")
                 .payload("{\"user\":\"atmos\",\"room_id\":123456}")
                 .create();
-        GHDeploymentStatus ghDeploymentStatus = deployment.createStatus(GHDeploymentState.SUCCESS)
+        GHDeploymentStatus ghDeploymentStatus = deployment.createStatus(GHDeploymentState.QUEUED)
                 .description("success")
                 .targetUrl("http://www.github.com")
+                .logUrl("http://www.github.com/logurl")
+                .environmentUrl("http://www.github.com/envurl")
+                .environment("new-ci-env")
                 .create();
         Iterable<GHDeploymentStatus> deploymentStatuses = deployment.listStatuses();
         assertNotNull(deploymentStatuses);
         assertEquals(1, Iterables.size(deploymentStatuses));
-        assertEquals(ghDeploymentStatus.getId(), Iterables.get(deploymentStatuses, 0).getId());
+        GHDeploymentStatus actualStatus = Iterables.get(deploymentStatuses, 0);
+        assertEquals(ghDeploymentStatus.getId(), actualStatus.getId());
+        assertEquals(ghDeploymentStatus.getState(), actualStatus.getState());
+        assertEquals(ghDeploymentStatus.getLogUrl(), actualStatus.getLogUrl());
+        // Target url was deprecated and replaced with log url. The gh api will
+        // prefer the log url value and return it in target field
+        assertEquals(ghDeploymentStatus.getTargetUrl(), actualStatus.getLogUrl());
+
     }
 
     @Test

--- a/src/test/java/org/kohsuke/github/GHDeploymentTest.java
+++ b/src/test/java/org/kohsuke/github/GHDeploymentTest.java
@@ -23,6 +23,9 @@ public class GHDeploymentTest extends AbstractGitHubWireMockTest {
         assertEquals("master", deployment.getRef());
         assertEquals("3a09d2de4a9a1322a0ba2c3e2f54a919ca8fe353", deployment.getSha());
         assertEquals("deploy", deployment.getTask());
+        assertEquals("production", deployment.getOriginalEnvironment());
+        assertEquals(false, deployment.isProductionEnvironment());
+        assertEquals(true, deployment.isTransientEnvironment());
     }
 
     @Test
@@ -41,6 +44,9 @@ public class GHDeploymentTest extends AbstractGitHubWireMockTest {
         assertEquals("two", payload.get("custom2"));
         assertEquals(Arrays.asList("3", 3, "three"), payload.get("custom3"));
         assertNull(payload.get("custom4"));
+        assertEquals("production", deployment.getOriginalEnvironment());
+        assertEquals(false, deployment.isProductionEnvironment());
+        assertEquals(true, deployment.isTransientEnvironment());
     }
 
     protected GHRepository getRepository() throws IOException {

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/__files/repos_hub4j-test-org_github-api-test_deployments-3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/__files/repos_hub4j-test-org_github-api-test_deployments-3.json
@@ -32,5 +32,7 @@
   "created_at": "2019-10-03T18:57:57Z",
   "updated_at": "2019-10-03T18:57:57Z",
   "statuses_url": "http://localhost:62379/repos/hub4j-test-org/github-api-test/deployments/173089055/statuses",
-  "repository_url": "http://localhost:62379/repos/hub4j-test-org/github-api-test"
+  "repository_url": "http://localhost:62379/repos/hub4j-test-org/github-api-test",
+  "transient_environment": true,
+  "production_environment": false
 }

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/__files/repos_hub4j-test-org_github-api-test_deployments-4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/__files/repos_hub4j-test-org_github-api-test_deployments-4.json
@@ -33,6 +33,8 @@
     "created_at": "2019-10-03T18:57:57Z",
     "updated_at": "2019-10-03T18:57:57Z",
     "statuses_url": "https://api.github.com/repos/hub4j-test-org/github-api-test/deployments/173089055/statuses",
-    "repository_url": "https://api.github.com/repos/hub4j-test-org/github-api-test"
+    "repository_url": "https://api.github.com/repos/hub4j-test-org/github-api-test",
+    "transient_environment": true,
+    "production_environment": false
   }
 ]

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_hub4j-test-org_github-api-test_deployments-3.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_hub4j-test-org_github-api-test_deployments-3.json
@@ -13,7 +13,7 @@
     ],
     "headers": {
       "Accept": {
-        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+        "equalTo": "application/vnd.github.ant-man-preview+json, application/vnd.github.flash-preview+json"
       }
     }
   },

--- a/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_hub4j-test-org_github-api-test_deployments-4.json
+++ b/src/test/resources/org/kohsuke/github/AppTest/wiremock/testCreateAndListDeployments/mappings/repos_hub4j-test-org_github-api-test_deployments-4.json
@@ -6,7 +6,7 @@
     "method": "GET",
     "headers": {
       "Accept": {
-        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+        "equalTo": "application/vnd.github.ant-man-preview+json, application/vnd.github.flash-preview+json"
       }
     }
   },

--- a/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdObjectPayload/__files/repos_hub4j-test-org_github-api_deployments_178653229-3.json
+++ b/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdObjectPayload/__files/repos_hub4j-test-org_github-api_deployments_178653229-3.json
@@ -37,5 +37,7 @@
   "created_at": "2019-10-30T00:03:34Z",
   "updated_at": "2019-10-30T00:03:34Z",
   "statuses_url": "https://api.github.com/repos/hub4j-test-org/github-api/deployments/178653229/statuses",
-  "repository_url": "https://api.github.com/repos/hub4j-test-org/github-api"
+  "repository_url": "https://api.github.com/repos/hub4j-test-org/github-api",
+  "transient_environment": true,
+  "production_environment": false
 }

--- a/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdObjectPayload/mappings/repos_hub4j-test-org_github-api_deployments_178653229-3.json
+++ b/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdObjectPayload/mappings/repos_hub4j-test-org_github-api_deployments_178653229-3.json
@@ -6,7 +6,7 @@
     "method": "GET",
     "headers": {
       "Accept": {
-        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+        "equalTo": "application/vnd.github.ant-man-preview+json, application/vnd.github.flash-preview+json"
       }
     }
   },

--- a/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdStringPayload/__files/repos_hub4j-test-org_github-api_deployments_178653229-3.json
+++ b/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdStringPayload/__files/repos_hub4j-test-org_github-api_deployments_178653229-3.json
@@ -32,5 +32,7 @@
   "created_at": "2019-10-30T00:03:34Z",
   "updated_at": "2019-10-30T00:03:34Z",
   "statuses_url": "https://api.github.com/repos/hub4j-test-org/github-api/deployments/178653229/statuses",
-  "repository_url": "https://api.github.com/repos/hub4j-test-org/github-api"
+  "repository_url": "https://api.github.com/repos/hub4j-test-org/github-api",
+  "transient_environment": true,
+  "production_environment": false
 }

--- a/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdStringPayload/mappings/repos_hub4j-test-org_github-api_deployments_178653229-3.json
+++ b/src/test/resources/org/kohsuke/github/GHDeploymentTest/wiremock/testGetDeploymentByIdStringPayload/mappings/repos_hub4j-test-org_github-api_deployments_178653229-3.json
@@ -6,7 +6,7 @@
     "method": "GET",
     "headers": {
       "Accept": {
-        "equalTo": "text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2"
+        "equalTo": "application/vnd.github.ant-man-preview+json, application/vnd.github.flash-preview+json"
       }
     }
   },


### PR DESCRIPTION
# Description 
* Implement deployment API support for ant-man and flash previews.
* This pr includes two new constants in the `Previews` class. 
* Getters for newly introduced fields are added to `GHDeployment` and `GHDeploymentStatus`.
* New builder setters are implemented for `GHDeploymentBuilder` and `GHDeploymentStatusBuilder`.
* `GHDeploymentState` has been updated to support `in_progress`, `queued`, and `inactive`. 
  * [Related Gh API Docs](https://docs.github.com/en/free-pro-team@latest/rest/reference/repos#create-a-deployment-status)
* Marked `GHDeploymentStatus.getTargetUrl()` and `GHDeploymentStatusBuilder.targetUrl()` as `@Deprecated`.
  * Method documentation has been updated with to notify users to replace usages with `logUrl()` where appropriate

# Before submitting a PR:
We love getting PRs, but we hate asking people for the same basic changes every time. 

- [X] Push your changes to a branch other than `master`. Create your PR from that branch.    
- [X] Add JavaDocs and other comments
- [ ] Write tests that run and pass in CI. See [CONTRIBUTING.md](CONTRIBUTING.md) for details on how to capture snapshot data.
- [ ] Run `mvn clean compile` locally. This may reformat your code, commit those changes.
- [ ] Run `mvn -D enable-ci clean install site` locally. If this command doesn't succeed, your change will not pass CI.

# When creating a PR: 

- [X] Fill in the "Description" above. 
- [X] Enable "Allow edits from maintainers". 
